### PR TITLE
Swap to 1.9 hash syntax and mark downcase_email method

### DIFF
--- a/swarmize-dot-com/app/controllers/admin_controller.rb
+++ b/swarmize-dot-com/app/controllers/admin_controller.rb
@@ -46,17 +46,17 @@ class AdminController < ApplicationController
 
   def do_create_dummy_swarms
     5.times do |n|
-      user = User.where(:is_fake => true).order("RANDOM()").first
+      user = User.where(is_fake: true).order("RANDOM()").first
       Dummy.create_dummy_preopen_swarm(user, n)
     end
 
     5.times do |n|
-      user = User.where(:is_fake => true).order("RANDOM()").first
+      user = User.where(is_fake: true).order("RANDOM()").first
       Dummy.create_dummy_live_swarm(user, n)
     end
 
     5.times do |n|
-      user = User.where(:is_fake => true).order("RANDOM()").first
+      user = User.where(is_fake: true).order("RANDOM()").first
       Dummy.create_dummy_closed_swarm(user, n)
     end
   end

--- a/swarmize-dot-com/app/controllers/csv_controller.rb
+++ b/swarmize-dot-com/app/controllers/csv_controller.rb
@@ -12,7 +12,7 @@ class CsvController < ApplicationController
       results.each do |result|
         csv << tool.result_to_row(result).to_s
       end
-      send_file csv, :filename => "#{@swarm.token}.csv"
+      send_file csv, filename: "#{@swarm.token}.csv"
     end
   end
 

--- a/swarmize-dot-com/app/controllers/graphs_controller.rb
+++ b/swarmize-dot-com/app/controllers/graphs_controller.rb
@@ -1,8 +1,8 @@
 class GraphsController < ApplicationController
   before_filter :scope_to_swarm
   before_filter :check_for_user, :only => %w{index new create edit update delete destroy}
-  before_filter :check_user_has_permissions_on_swarm, :only => %w{index new create edit update delete destroy}
-  before_filter :scope_to_graph, :only => %w{edit update delete destroy}
+  before_filter :check_user_has_permissions_on_swarm, only: %w{index new create edit update delete destroy}
+  before_filter :scope_to_graph, only: %w{edit update delete destroy}
 
   def index
     @graphs = @swarm.graphs
@@ -54,7 +54,7 @@ class GraphsController < ApplicationController
       results[hash.keys.first] = hash.values.first
     end
     
-    render :json => results
+    render json: results
   end
 
   def cardinal_count
@@ -63,7 +63,7 @@ class GraphsController < ApplicationController
       results[hash.keys.first] = hash.values.first
     end
 
-    render :json => results
+    render json: results
   end
 
   def count_over_time
@@ -78,7 +78,7 @@ class GraphsController < ApplicationController
        data: data}
     end
 
-    render :json => results
+    render json: results
   end
 
   private
@@ -106,7 +106,7 @@ class GraphsController < ApplicationController
   end
 
   def setup_graphable_fields
-    graphable_fields = @swarm.swarm_fields.where(:field_type => SwarmField.graphable)
+    graphable_fields = @swarm.swarm_fields.where(field_type: SwarmField.graphable)
     if graphable_fields.any?
       @graphable_fields = graphable_fields.map do |f|
         [f.field_name, f.field_code]

--- a/swarmize-dot-com/app/controllers/oembed_controller.rb
+++ b/swarmize-dot-com/app/controllers/oembed_controller.rb
@@ -1,7 +1,7 @@
 class OembedController < ApplicationController
   def show
     if params[:format] == 'xml'
-      render :status => 501, :text => 'Format not supported'
+      render :status => 501, text: 'Format not supported'
       return
     end
 

--- a/swarmize-dot-com/app/controllers/permissions_controller.rb
+++ b/swarmize-dot-com/app/controllers/permissions_controller.rb
@@ -1,8 +1,8 @@
 class PermissionsController < ApplicationController
   before_filter :scope_to_swarm
-  before_filter :check_for_user, :only => :index
-  before_filter :check_user_can_alter_permissions, :except => :index
-  before_filter :scope_to_permission, :only => %w{destroy}
+  before_filter :check_for_user, only: :index
+  before_filter :check_user_can_alter_permissions, except: :index
+  before_filter :scope_to_permission, only: %w{destroy}
 
   def index
     @access_permissions = @swarm.access_permissions 
@@ -22,15 +22,15 @@ class PermissionsController < ApplicationController
     email = EmailValidator.normalize_email(params[:email])
 
     @user = User.find_by email: email
-    ap = AccessPermission.where(:swarm => @swarm, :email => email)
+    ap = AccessPermission.where(swarm: @swarm, email: email)
     if(!ap.empty?)
       flash[:error] = "That user already has permissions on this swarm."
       redirect_to swarm_permissions_path(@swarm) and return
     else
-      @access_permission = AccessPermission.create(:swarm => @swarm,
-                                                   :user => @user,
-                                                   :creator => @current_user,
-                                                   :email => email)
+      @access_permission = AccessPermission.create(swarm: @swarm,
+                                                   user: @user,
+                                                   creator: @current_user,
+                                                   email: email)
       PermissionMailer.permission_email(email, @swarm).deliver
       flash[:success] = "#{email} has been given permission to alter this swarm. They've been sent an email notifying them of this fact!"
       redirect_to swarm_permissions_path(@swarm) and return

--- a/swarmize-dot-com/app/controllers/swarms_controller.rb
+++ b/swarmize-dot-com/app/controllers/swarms_controller.rb
@@ -1,31 +1,31 @@
 class SwarmsController < ApplicationController
-  before_filter :scope_to_swarm, :except => %w{index draft live closed new create mine embed}
-  before_filter :scope_to_swarm_for_embed, :only => %w{embed}
-  before_filter :check_for_user, :except => %w{embed}
-  before_filter :count_swarms, :only => %w{index draft live closed}
-  before_filter :check_user_can_alter_swarm, :only => %w{edit update fields update_fields preview open close code}
-  before_filter :check_user_can_destroy_swarm, :only => %w{delete destroy}
+  before_filter :scope_to_swarm, except: %w{index draft live closed new create mine embed}
+  before_filter :scope_to_swarm_for_embed, only: %w{embed}
+  before_filter :check_for_user, except: %w{embed}
+  before_filter :count_swarms, only: %w{index draft live closed}
+  before_filter :check_user_can_alter_swarm, only: %w{edit update fields update_fields preview open close code}
+  before_filter :check_user_can_destroy_swarm, only: %w{delete destroy}
 
   respond_to :html, :json
 
   def index
     if @current_user
-      @swarms = Swarm.order("created_at DESC").paginate(:page => params[:page])
+      @swarms = Swarm.order("created_at DESC").paginate(page: params[:page])
     else
-      @swarms = Swarm.order("created_at DESC").publicly_visible.paginate(:page => params[:page])
+      @swarms = Swarm.order("created_at DESC").publicly_visible.paginate(page: params[:page])
     end
   end
 
   def draft
-    @swarms = Swarm.order("created_at DESC").draft.paginate(:page => params[:page])
+    @swarms = Swarm.order("created_at DESC").draft.paginate(page: params[:page])
   end
 
   def live
-    @swarms = Swarm.order("created_at DESC").live.paginate(:page => params[:page])
+    @swarms = Swarm.order("created_at DESC").live.paginate(page: params[:page])
   end
   
   def closed
-    @swarms = Swarm.order("created_at DESC").closed.paginate(:page => params[:page])
+    @swarms = Swarm.order("created_at DESC").closed.paginate(page: params[:page])
   end
 
   def mine
@@ -107,7 +107,7 @@ class SwarmsController < ApplicationController
 
   def embed
     response.headers.delete('X-Frame-Options')
-    expires_in 1.minute, :public => true
+    expires_in 1.minute, public: true
     
     render layout: 'embed'
   end
@@ -116,10 +116,10 @@ class SwarmsController < ApplicationController
     swarm = Swarm.new(swarm_params)
     swarm.save
 
-    AccessPermission.create(:swarm => swarm,
-                            :user => @current_user,
-                            :email => @current_user.email,
-                            :is_owner => true)
+    AccessPermission.create(swarm: swarm,
+                            user: @current_user,
+                            email: @current_user.email,
+                            is_owner: true)
 
     redirect_to fields_swarm_path(swarm)
   end
@@ -138,7 +138,7 @@ class SwarmsController < ApplicationController
                                 params['open_day'],
                                 params['open_hour'],
                                 params['open_minute'])
-    @swarm.update(:opens_at => open_time)
+    @swarm.update(opens_at: open_time)
     redirect_to @swarm
   end
 
@@ -150,7 +150,7 @@ class SwarmsController < ApplicationController
                                  params['close_minute'])
 
     begin
-      @swarm.update(:closes_at => close_time)
+      @swarm.update(closes_at: close_time)
     rescue TimeParadoxError
       flash[:error] = "Swarm cannot close before it has opened!"
     end

--- a/swarmize-dot-com/app/controllers/users_controller.rb
+++ b/swarmize-dot-com/app/controllers/users_controller.rb
@@ -1,28 +1,28 @@
 class UsersController < ApplicationController
-  before_filter :check_for_user, :only => %w{show live closed draft}
-  before_filter :check_for_admin, :except => %w{show live closed draft}
-  before_filter :scope_to_user, :except => %w{index new create}
-  before_filter :check_can_see_drafts, :only => :draft
-  before_filter :count_swarms, :only => %w{show draft live closed}
+  before_filter :check_for_user, only: %w{show live closed draft}
+  before_filter :check_for_admin, except: %w{show live closed draft}
+  before_filter :scope_to_user, except: %w{index new create}
+  before_filter :check_can_see_drafts, only: :draft
+  before_filter :count_swarms, only: %w{show draft live closed}
 
   def index
-    @users = User.paginate(:page => params[:page])
+    @users = User.paginate(page: params[:page])
   end
 
   def show
-    @swarms = @user.swarms.paginate(:page => params[:page])
+    @swarms = @user.swarms.paginate(page: params[:page])
   end
 
   def draft
-    @swarms = @user.swarms.draft.paginate(:page => params[:page])
+    @swarms = @user.swarms.draft.paginate(page: params[:page])
   end
 
   def live
-    @swarms = @user.swarms.live.paginate(:page => params[:page])
+    @swarms = @user.swarms.live.paginate(page: params[:page])
   end
   
   def closed
-    @swarms = @user.swarms.closed.paginate(:page => params[:page])
+    @swarms = @user.swarms.closed.paginate(page: params[:page])
   end
 
   def delete

--- a/swarmize-dot-com/app/controllers/utils_controller.rb
+++ b/swarmize-dot-com/app/controllers/utils_controller.rb
@@ -1,5 +1,5 @@
 class UtilsController < ApplicationController
   def name_to_code
-    render :text => params[:name].strip.parameterize.underscore
+    render text: params[:name].strip.parameterize.underscore
   end
 end

--- a/swarmize-dot-com/app/helpers/application_helper.rb
+++ b/swarmize-dot-com/app/helpers/application_helper.rb
@@ -13,7 +13,7 @@ module ApplicationHelper
       options, collection_or_options = collection_or_options, nil
     end
     unless options[:renderer]
-      options = options.merge :renderer => BootstrapPagination::Rails
+      options = options.merge renderer: BootstrapPagination::Rails
     end
     super *[collection_or_options, options].compact
   end

--- a/swarmize-dot-com/app/models/access_permission.rb
+++ b/swarmize-dot-com/app/models/access_permission.rb
@@ -1,9 +1,9 @@
 class AccessPermission < ActiveRecord::Base
   belongs_to :swarm
   belongs_to :user
-  belongs_to :creator, :class_name => 'User', :foreign_key => 'creator_id'
+  belongs_to :creator, class_name: 'User', foreign_key: 'creator_id'
 
-  before_save :downcase_email
+  before_save :downcase_email!
 
   validates :email, uniqueness: { scope: :swarm,
     message: "can only be given permission on a swarm once" }
@@ -41,7 +41,7 @@ class AccessPermission < ActiveRecord::Base
   end
   private
 
-  def downcase_email
+  def downcase_email!
     self.email = self.email.downcase
   end
 

--- a/swarmize-dot-com/app/models/swarm.rb
+++ b/swarmize-dot-com/app/models/swarm.rb
@@ -12,7 +12,7 @@ class Swarm < ActiveRecord::Base
   has_many :clones, class_name: 'Swarm', foreign_key: 'cloned_from'
 
   has_many :access_permissions
-  has_many :unassigned_access_permissions, -> { where('user_id IS NULL') }, :class_name => 'AccessPermission'
+  has_many :unassigned_access_permissions, -> { where('user_id IS NULL') }, class_name: 'AccessPermission'
   has_many :users, through: :access_permissions
   has_many :owners, -> { where('access_permissions.is_owner' => true) }, through: :access_permissions, source: :user
 
@@ -45,8 +45,8 @@ class Swarm < ActiveRecord::Base
   }
 
   pg_search_scope :search_by_name_and_description, against: {
-    :name => 'A', 
-    :description => 'B'
+    name: 'A', 
+    description: 'B'
   }
 
   def creator
@@ -63,14 +63,14 @@ class Swarm < ActiveRecord::Base
   end
 
   def as_json(options={})
-    {:name => self.name,
-     :description => self.description,
-     :fields => self.swarm_fields,
-     :opens_at => self.opens_at,
-     :closes_at => self.closes_at,
-     :token => self.token,
-     :display_title => self.display_title,
-     :display_description => self.display_description
+    {name: self.name,
+     description: self.description,
+     fields: self.swarm_fields,
+     opens_at: self.opens_at,
+     closes_at: self.closes_at,
+     token: self.token,
+     display_title: self.display_title,
+     display_description: self.display_description
     }
   end
 
@@ -97,10 +97,10 @@ class Swarm < ActiveRecord::Base
 
     new_swarm.save
 
-    AccessPermission.create(:swarm => new_swarm,
-                            :user => user,
-                            :email => user.email,
-                            :is_owner => true)
+    AccessPermission.create(swarm: new_swarm,
+                            user: user,
+                            email: user.email,
+                            is_owner: true)
 
     self.swarm_fields.each do |f|
       new_f = f.dup

--- a/swarmize-dot-com/app/models/swarm.rb
+++ b/swarmize-dot-com/app/models/swarm.rb
@@ -5,16 +5,16 @@ class Swarm < ActiveRecord::Base
 
   acts_as_paranoid
 
-  belongs_to :parent_swarm, :class_name => 'Swarm', :foreign_key => 'cloned_from'
+  belongs_to :parent_swarm, class_name: 'Swarm', foreign_key: 'cloned_from'
 
-  has_many :swarm_fields, -> { order('field_index ASC') }, :dependent => :destroy
+  has_many :swarm_fields, -> { order('field_index ASC') }, dependent: :destroy
   has_many :graphs
-  has_many :clones, :class_name => 'Swarm', :foreign_key => 'cloned_from'
+  has_many :clones, class_name: 'Swarm', foreign_key: 'cloned_from'
 
   has_many :access_permissions
   has_many :unassigned_access_permissions, -> { where('user_id IS NULL') }, :class_name => 'AccessPermission'
-  has_many :users, :through => :access_permissions
-  has_many :owners, -> { where('access_permissions.is_owner' => true) }, :through => :access_permissions, :source => :user
+  has_many :users, through: :access_permissions
+  has_many :owners, -> { where('access_permissions.is_owner' => true) }, through: :access_permissions, source: :user
 
   before_create :setup_token
 
@@ -44,7 +44,7 @@ class Swarm < ActiveRecord::Base
     where("opens_at <= ?", Time.zone.now).where("closes_at IS NULL or closes_at > ?", Time.zone.now).order('opens_at DESC')
   }
 
-  pg_search_scope :search_by_name_and_description, :against => {
+  pg_search_scope :search_by_name_and_description, against: {
     :name => 'A', 
     :description => 'B'
   }
@@ -175,7 +175,7 @@ class Swarm < ActiveRecord::Base
 
   def api_keys
     keys = []
-    APIKey.all.where(:swarm_token => self.token).select do |item_data|
+    APIKey.all.where(swarm_token: self.token).select do |item_data|
         keys << item_data.attributes #=> { 'id' => 'abc', 'category' => 'foo', ... }
     end
 

--- a/swarmize-dot-com/app/models/swarm_field.rb
+++ b/swarmize-dot-com/app/models/swarm_field.rb
@@ -6,10 +6,10 @@ class SwarmField < ActiveRecord::Base
   before_create :set_code 
 
   def as_json(options={})
-    json_fields = {:field_type => self.field_type,
-         :field_name => self.field_name,
-         :field_name_code => self.field_code,
-         :compulsory => self.compulsory}
+    json_fields = {field_type: self.field_type,
+         field_name: self.field_name,
+         field_name_code: self.field_code,
+         compulsory: self.compulsory}
 
     if description.has_maximum && self.maximum
       json_fields[:maximum] = self.maximum

--- a/swarmize-dot-com/app/models/user.rb
+++ b/swarmize-dot-com/app/models/user.rb
@@ -1,22 +1,22 @@
 class User < ActiveRecord::Base
   has_many :access_permissions
-  has_many :swarms, :through => :access_permissions
+  has_many :swarms, through: :access_permissions
   has_many :owned_swarms, -> { where('access_permissions.is_owner' => true) }, :through => :access_permissions, :source => :swarm
 
-  before_save :downcase_email
+  before_save :downcase_email!
   after_create :update_access_permissions
 
   def self.find_or_create_from_info_hash(info_hash)
     self.find_or_create_by(
-      :email => EmailValidator.normalize_email(info_hash['email']),
-      :name => info_hash['name'],
-      :image_url => info_hash['image']
+      email: EmailValidator.normalize_email(info_hash['email']),
+      name: info_hash['name'],
+      image_url: info_hash['image']
     )
   end
 
   private
 
-  def downcase_email
+  def downcase_email!
     self.email = self.email.downcase
   end
 

--- a/swarmize-dot-com/app/models/user.rb
+++ b/swarmize-dot-com/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   has_many :access_permissions
   has_many :swarms, through: :access_permissions
-  has_many :owned_swarms, -> { where('access_permissions.is_owner' => true) }, :through => :access_permissions, :source => :swarm
+  has_many :owned_swarms, -> { where('access_permissions.is_owner' => true) }, through: :access_permissions, source: :swarm
 
   before_save :downcase_email!
   after_create :update_access_permissions

--- a/swarmize-dot-com/config/initializers/omniauth.rb
+++ b/swarmize-dot-com/config/initializers/omniauth.rb
@@ -1,5 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], {
-    :prompt => 'select_account'
+    prompt: 'select_account'
   }
 end

--- a/swarmize-dot-com/lib/dummy.rb
+++ b/swarmize-dot-com/lib/dummy.rb
@@ -40,7 +40,7 @@ class Dummy
   end
 
   def self.destroy_fake_data
-    fake_users = User.where(:is_fake => true)
+    fake_users = User.where(is_fake: true)
     fake_users.each do |u|
       u.swarms.destroy_all
     end

--- a/swarmize-dot-com/lib/json_importer.rb
+++ b/swarmize-dot-com/lib/json_importer.rb
@@ -28,17 +28,17 @@ class JSONImporter
       closes_at = nil
     end
 
-    swarm = Swarm.create(:name => json.name + " [IMPORTED]",
-                         :description => json.description,
-                         :opens_at => opens_at,
-                         :closes_at => closes_at,
-                         :token => json.token)
+    swarm = Swarm.create(name: json.name + " [IMPORTED]",
+                         description: json.description,
+                         opens_at: opens_at,
+                         closes_at: closes_at,
+                         token: json.token)
 
     if user
-      AccessPermission.create(:swarm => swarm,
-                              :user => user,
-                              :email => user.email,
-                              :is_owner => true)
+      AccessPermission.create(swarm: swarm,
+                              user: user,
+                              email: user.email,
+                              is_owner: true)
     end
 
     swarm
@@ -51,17 +51,17 @@ class JSONImporter
       else
         possible_values = nil
       end
-      SwarmField.create(:field_index => i+1,
-                        :field_type => field.field_type,
-                        :field_name => field.field_name,
-                        :field_code => field.field_name_code,
-                        :hint => field.hint,
-                        :sample_value => field.sample_value,
-                        :compulsory => field.compulsory,
-                        :minimum => field.minimum,
-                        :maximum => field.maximum,
-                        :possible_values => possible_values,
-                        :swarm => swarm)
+      SwarmField.create(field_index: i+1,
+                        field_type: field.field_type,
+                        field_name: field.field_name,
+                        field_code: field.field_name_code,
+                        hint: field.hint,
+                        sample_value: field.sample_value,
+                        compulsory: field.compulsory,
+                        minimum: field.minimum,
+                        maximum: field.maximum,
+                        possible_values: possible_values,
+                        swarm: swarm)
     end
 
   end

--- a/swarmize-dot-com/lib/tasks/swarmize.rake
+++ b/swarmize-dot-com/lib/tasks/swarmize.rake
@@ -6,16 +6,16 @@ namespace :swarmize do
     task :dummy_up => [:destroy_fake_data,:create_fake_users,:insert_dummy_swarms]
 
     desc "Destroy fake data"
-    task :destroy_fake_data => :environment do
+    task destroy_fake_data: :environment do
       puts "Destroying all old data."
       Dummy.destroy_fake_data
     end
 
     desc "Insert dummy swarms"
-    task :insert_dummy_swarms => [:insert_dummy_preopen_swarms, :insert_dummy_live_swarms, :insert_dummy_closed_swarms]
+    task insert_dummy_swarms: [:insert_dummy_preopen_swarms, :insert_dummy_live_swarms, :insert_dummy_closed_swarms]
 
     desc "Insert some dummy yet-to-open swarms"
-    task :insert_dummy_preopen_swarms => :environment do
+    task insert_dummy_preopen_swarms: :environment do
       5.times do |n|
         user = User.where(:is_fake => true).order("RANDOM()").first
         s = Dummy.create_dummy_preopen_swarm(user, n)
@@ -24,25 +24,25 @@ namespace :swarmize do
     end
 
     desc "Insert some dummy live swarms"
-    task :insert_dummy_live_swarms => :environment do
+    task insert_dummy_live_swarms: :environment do
       5.times do |n|
-        user = User.where(:is_fake => true).order("RANDOM()").first
+        user = User.where(is_fake: true).order("RANDOM()").first
         s = Dummy.create_dummy_live_swarm(user, n)
         puts "Created #{s.name}"
       end
     end
 
     desc "Insert some dummy closed swarms"
-    task :insert_dummy_closed_swarms => :environment do
+    task insert_dummy_closed_swarms: :environment do
       5.times do |n|
-        user = User.where(:is_fake => true).order("RANDOM()").first
+        user = User.where(is_fake: true).order("RANDOM()").first
         s = Dummy.create_dummy_closed_swarm(user, n)
         puts "Created #{s.name}"
       end
     end
 
     desc "Insert some fake users"
-    task :create_fake_users => :environment do
+    task create_fake_users: :environment do
       5.times do
         u = Dummy.create_fake_user
         puts "Created #{u.name}"
@@ -50,10 +50,10 @@ namespace :swarmize do
     end
 
     desc "Insert tokens for swarms with no tokens"
-    task :backfill_tokens => :environment do
+    task backfill_tokens: :environment do
       require 'securerandom'
 
-      Swarm.where(:token => nil).each do |swarm|
+      Swarm.where(token: nil).each do |swarm|
         t = SecureRandom.urlsafe_base64(6)
         until (t.length == 8) && !Swarm.find_by_token(t)
           t = SecureRandom.urlsafe_base64(6)
@@ -65,7 +65,7 @@ namespace :swarmize do
     end
 
     desc "Backfill SwarmField objects for swarms"
-    task :backfill_fields => :environment do
+    task backfill_fields: :environment do
       Swarm.all.each do |swarm|
         if swarm.fields && swarm.fields.any?
           swarm.fields.each do |original_field|
@@ -88,17 +88,17 @@ namespace :swarmize do
     end
 
     desc "Destroy all SwarmFields"
-    task :destroy_fields => :environment do
+    task destroy_fields: :environment do
       SwarmField.destroy_all
     end
 
     desc "Set up access permissions for existing swarms."
-    task :give_owners_permissions => :environment do
+    task give_owners_permissions: :environment do
       Swarm.all.each do |swarm|
-        AccessPermission.create(:swarm => swarm,
-                                :user => swarm.creator,
-                                :email => swarm.creator.email,
-                                :is_owner => true)
+        AccessPermission.create(swarm: swarm,
+                                user: swarm.creator,
+                                email: swarm.creator.email,
+                                is_owner: true)
         print "."
       end
       puts


### PR DESCRIPTION
Notice the .ruby-version enforces 1.9.3 so swapped the hash syntax in the models to 1.9 mode. Also note that the downcase_email method modifies the email direct so marked it with a bang to indicate this behaviour.
